### PR TITLE
support OIDC authentication

### DIFF
--- a/corezoid/charts/ingress-aws-dual/.helmignore
+++ b/corezoid/charts/ingress-aws-dual/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/corezoid/charts/ingress-aws-dual/Chart.yaml
+++ b/corezoid/charts/ingress-aws-dual/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: ingress-aws-dual
+version: 0.1.0

--- a/corezoid/charts/ingress-aws-dual/templates/internal.yaml
+++ b/corezoid/charts/ingress-aws-dual/templates/internal.yaml
@@ -1,0 +1,21 @@
+{{- if eq .Values.global.ingress "aws-dual" }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Values.appName }}-{{ .Values.global.environment }}-internal
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.alb.certificatearn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /ping
+    alb.ingress.kubernetes.io/success-codes: '200'
+    alb.ingress.kubernetes.io/scheme: internal
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.global.subdomain }}.{{ .Values.global.domain }}
+  labels:
+    environment: {{ .Values.global.environment }}
+    app: {{ .Values.global.product }}
+    tier: {{ .Values.appName }}
+spec:
+  backend:
+    serviceName: "corezoid-web-adm"
+    servicePort: 80
+{{- end }}

--- a/corezoid/charts/ingress-aws-dual/templates/internet-facing.yaml
+++ b/corezoid/charts/ingress-aws-dual/templates/internet-facing.yaml
@@ -1,0 +1,25 @@
+{{- if eq .Values.global.ingress "aws-dual" }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Values.appName }}-{{ .Values.global.environment }}-internet-facing
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.alb.certificatearn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /ping
+    alb.ingress.kubernetes.io/success-codes: '200'
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.global.subdomain }}.{{ .Values.global.domain }}
+    {{- if .Values.global.alb.oidc.enabled }}
+    alb.ingress.kubernetes.io/auth-type: oidc
+    alb.ingress.kubernetes.io/auth-idp-oidc: '{"Issuer": "{{ .Values.global.alb.oidc.issuer }}","AuthorizationEndpoint": "{{ .Values.global.alb.oidc.endpoints.authorize }}","TokenEndpoint": "{{ .Values.global.alb.oidc.endpoints.token }}","UserInfoEndpoint": "{{ .Values.global.alb.oidc.endpoints.userinfo }}","SecretName": "{{ .Values.appName }}-{{ .Values.global.environment }}-alb-oidc"}'
+    {{ end }}
+  labels:
+    environment: {{ .Values.global.environment }}
+    app: {{ .Values.global.product }}
+    tier: {{ .Values.appName }}
+spec:
+  backend:
+    serviceName: "corezoid-web-adm"
+    servicePort: 80
+{{- end }}

--- a/corezoid/charts/ingress-aws-dual/templates/oidc-secret.yaml
+++ b/corezoid/charts/ingress-aws-dual/templates/oidc-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.global.alb.oidc.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ .Values.appName }}-{{ .Values.global.environment }}-alb-oidc
+data:
+    clientId: {{ .Values.global.alb.oidc.clientId | b64enc | quote }}
+    clientSecret: {{ .Values.global.alb.oidc.clientSecret |b64enc | quote }}
+{{- end }}

--- a/corezoid/charts/ingress-aws-dual/values.yaml
+++ b/corezoid/charts/ingress-aws-dual/values.yaml
@@ -1,0 +1,1 @@
+appName: cz-ingress

--- a/corezoid/charts/ingress-aws/templates/cz-eks-ingress.yml
+++ b/corezoid/charts/ingress-aws/templates/cz-eks-ingress.yml
@@ -5,11 +5,15 @@ metadata:
   name: {{ .Values.appName }}-{{ .Values.global.environment }}
   annotations:
     kubernetes.io/ingress.class: alb
-    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.certificatearn }}
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.global.alb.certificatearn }}
     alb.ingress.kubernetes.io/healthcheck-path: /ping
     alb.ingress.kubernetes.io/success-codes: '200'
-    alb.ingress.kubernetes.io/scheme: {{ .Values.global.alb }}
+    alb.ingress.kubernetes.io/scheme: {{ .Values.global.alb.scheme }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.global.subdomain }}.{{ .Values.global.domain }}
+    {{- if .Values.global.alb.oidc.enabled }}
+    alb.ingress.kubernetes.io/auth-type: oidc
+    alb.ingress.kubernetes.io/auth-idp-oidc: '{"Issuer": "{{ .Values.global.alb.oidc.issuer }}","AuthorizationEndpoint": "{{ .Values.global.alb.oidc.endpoints.authorize }}","TokenEndpoint": "{{ .Values.global.alb.oidc.endpoints.token }}","UserInfoEndpoint": "{{ .Values.global.alb.oidc.endpoints.userinfo }}","SecretName": "{{ .Values.appName }}-{{ .Values.global.environment }}-alb-oidc"}'
+    {{ end }}
   labels:
     environment: {{ .Values.global.environment }}
     app: {{ .Values.global.product }}

--- a/corezoid/charts/ingress-aws/templates/oidc-secret.yaml
+++ b/corezoid/charts/ingress-aws/templates/oidc-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.global.alb.oidc.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: {{ .Values.appName }}-{{ .Values.global.environment }}-alb-oidc
+data:
+    clientId: {{ .Values.global.alb.oidc.clientId | b64enc | quote }}
+    clientSecret: {{ .Values.global.alb.oidc.clientSecret |b64enc | quote }}
+{{- end }}

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -22,8 +22,18 @@ global:
   ingress: nginx
 
   # AWS ELB
-  alb: internet-facing
-  certificatearn: arn:aws:acm:eu-west-1:000000000000:certificate/000000-000000-0000-000-0000000000
+  alb:
+    scheme: internet-facing
+    certificatearn: arn:aws:acm:eu-west-1:000000000000:certificate/000000-000000-0000-000-0000000000
+    oidc:
+      enabled: false
+      issuer: https://idp.com
+      endpoints:
+        authorize: https://idp.com/oauth2/v1/authorize
+        token: https://idp.com/oauth2/v1/token
+        userinfo: https://idp.com/oauth2/v1/userinfo
+      clientId: identifier
+      clientSecret: secret
 
   #Nginx ingress options
   # default self signed ssl for corezoid-k8s.middleware.loc

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -18,7 +18,7 @@ global:
   product: corezoid
 
 
-  # Ingress: aws or nginx
+  # Ingress: aws or nginx or aws-dual
   ingress: nginx
 
   # AWS ELB
@@ -34,6 +34,26 @@ global:
         userinfo: https://idp.com/oauth2/v1/userinfo
       clientId: identifier
       clientSecret: secret
+
+  # If using aws-dual you will need two instances of external-dns running
+  # Here is an example helmfile, filtering on load balancer scheme and selecting
+  # appropriate AWS Route53 zone types
+  #   - name: external-dns-public
+  #     namespace: kube-system
+  #     chart: stable/external-dns
+  #     values:
+  #     - annotationFilter: alb.ingress.kubernetes.io/scheme=internet-facing
+  #     - aws:
+  #         zoneType: public
+  #
+  #   - name: external-dns-private
+  #     namespace: kube-system
+  #     chart: stable/external-dns
+  #     values:
+  #         - annotationFilter: alb.ingress.kubernetes.io/scheme=internal
+  #         - aws:
+  #             zoneType: private
+
 
   #Nginx ingress options
   # default self signed ssl for corezoid-k8s.middleware.loc


### PR DESCRIPTION
I've added configuration to support OIDC authentication in the ALB, and also:

- removed port 80 by default (ALBs will remove this if a certificate is provided which is surely correct behaviour)
- slightly restructured the values so it is easier to extend the alb configuration if needed

This appears to be working for us with Okta as an IdP.