### PR TITLE
Configuration improvements

### DIFF
--- a/corezoid/charts/capi/templates/capi-configmap.yaml
+++ b/corezoid/charts/capi/templates/capi-configmap.yaml
@@ -367,7 +367,7 @@ data:
                 {check_2fa, {{ .Values.global.capi.check_2fa | default "false" }} },
                 {init_password, <<"{{ .Values.global.capi.init_admin_password }}">>},
                 {login_attempts, {{ .Values.global.capi.login_attempts | default "5" }} },
-                {share_api_keys_in_company, false},
+                {share_api_keys_in_company, {{ .Values.global.capi.share_api_keys_in_company | default "false" }} },
                 {prometheus_metrics, {{ .Values.global.prometheus_metrics | default false }}  },
                 {use_limits_from_server, {{ .Values.global.use_limits_from_server | default false }}},
                 {redis_users, [[
@@ -415,8 +415,8 @@ data:
                   {password, "${FDW_POSTGRES_DBPWD}"}
                 ]},
 
-                {max_task_size_for_process_conv, 264000}, %% max task size for process conv
-                {max_task_size_for_st_diagramm_conv, 264000}, %% max task size for state diagramm conv
+                {max_task_size_for_process_conv, {{ .Values.global.capi.max_task_size_for_process_conv | default 264000 }} }, %% max task size for process conv
+                {max_task_size_for_st_diagramm_conv, {{ .Values.global.capi.max_task_size_for_st_diagramm_conv | default 264000 }} }, %% max task size for state diagramm conv
                 {origin_whitelist, [
                     "{{ .Values.global.subdomain}}.{{ .Values.global.domain }}","{{ .Values.global.web_superadm.subdomain}}.{{ .Values.global.domain }}","{{ .Values.global.syncapi.subdomain}}.{{ .Values.global.domain }}"
                 ]},

--- a/corezoid/charts/capi/templates/capi-deployment.yaml
+++ b/corezoid/charts/capi/templates/capi-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.capi.minReplicas }}
   template:
     metadata:
       annotations:

--- a/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
+++ b/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.conf_agent_server.minReplicas }}
   template:
     metadata:
       annotations:
@@ -179,3 +178,7 @@ spec:
           hostPath:
             path: /var/dumps
         {{- end }}
+      {{ if .Values.global.conf_agent_server.affinity }}
+      affinity:
+        {{ .Values.global.conf_agent_server.affinity | toYaml | nindent 8 | trim }}
+      {{- end}}

--- a/corezoid/charts/enigma-key-manager/templates/enigma-key-manager-deployment.yaml
+++ b/corezoid/charts/enigma-key-manager/templates/enigma-key-manager-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 25%
-  replicas: {{ .Values.global.enigma.key_manager.minReplicas }}
   template: # create pods using pod definition in this template
     metadata:
       annotations:

--- a/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
@@ -9,7 +9,6 @@ spec:
   selector:
     matchLabels:
       tier: {{ .Values.appName }}
-  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress.yaml
@@ -128,7 +128,7 @@ spec:
                 name: dump-service-node
                 port:
                   number: 80
-  {{- end }}
+    {{- end }}
   {{- if .Values.global.ingress_tls }}
   tls:
     - hosts:

--- a/corezoid/charts/merchant/templates/merchant-autoscale.yaml
+++ b/corezoid/charts/merchant/templates/merchant-autoscale.yaml
@@ -6,8 +6,8 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
-  minReplicas: 1
-  maxReplicas: 1
+  minReplicas: {{ .Values.global.merchant.minReplicas }}
+  maxReplicas: {{ .Values.global.merchant.maxReplicas }}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/corezoid/charts/merchant/templates/merchant-deployment.yaml
+++ b/corezoid/charts/merchant/templates/merchant-deployment.yaml
@@ -11,7 +11,6 @@ spec:
       tier: {{ .Values.appName }}
   strategy:
     type: RollingUpdate
-  replicas: {{ .Values.global.merchant.minReplicas }}
   template:
     metadata:
       annotations:

--- a/corezoid/charts/mult/templates/mult-deployment.yaml
+++ b/corezoid/charts/mult/templates/mult-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.mult.minReplicas }}
   template:
     metadata:
       annotations:
@@ -31,6 +30,9 @@ spec:
         {{ .Values.global.mult.affinity | toYaml | nindent 8 | trim }}
       {{- end}}
       terminationGracePeriodSeconds: 300
+      {{ if .Values.global.mult.schedulerName }}
+      schedulerName: {{ .Values.global.mult.schedulerName }}
+      {{- end }}
       securityContext:
         fsGroup: 1000
       initContainers:

--- a/corezoid/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/corezoid/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
-  replicas: {{ .Values.global.db.bouncer_minReplicas }}
   selector:
     matchLabels:
       tier: {{ .Values.appName }}

--- a/corezoid/charts/syncapi/templates/syncapi-deployment.yaml
+++ b/corezoid/charts/syncapi/templates/syncapi-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.syncapi.minReplicas }}
   template:
     metadata:
       annotations:

--- a/corezoid/charts/usercode/templates/usercode-configmap.yaml
+++ b/corezoid/charts/usercode/templates/usercode-configmap.yaml
@@ -164,7 +164,7 @@ data:
         {light_cnode_watchdog_wakeup,  1000}, %% time when watchdog wakes up and kills "longlive" codes in light nodes
         {heavy_cnode_watchdog_wakeup, 800}, %% time when watchdog wakes up and kills "longlive" codes in heavy nodes
 
-        {cnode_max_exec_code_time, 1000}, %% max time for each execution of code, kill process after this time
+        {cnode_max_exec_code_time, {{ .Values.global.usercode.max_exec_code_time | default 1000 }}}, %% max time for each execution of code, kill process after this time
         %% if code not used for that time - the compiled code and internal related  data will be cleaned up
         {cnode_code_no_usage_ttl_ms, 60000},
 

--- a/corezoid/charts/usercode/templates/usercode-deployment.yaml
+++ b/corezoid/charts/usercode/templates/usercode-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.usercode.minReplicas | default 2 }} # tells deployment to run 2 pods matching the template
   template: # create pods using pod definition in this template
     metadata:
       annotations:

--- a/corezoid/charts/worker/templates/worker-configmap.yaml
+++ b/corezoid/charts/worker/templates/worker-configmap.yaml
@@ -323,10 +323,10 @@ data:
         { max_task_size, 512000 },
 
         %% max task size for process conv
-        {max_task_size_for_process_conv, 512000},
+        {max_task_size_for_process_conv, {{ .Values.global.capi.max_task_size_for_process_conv | default 512000 }} },
 
         %% max task size for state diagramm conv
-        {max_task_size_for_st_diagramm_conv, 512000},
+        {max_task_size_for_st_diagramm_conv, {{ .Values.global.capi.max_task_size_for_st_diagramm_conv | default 512000 }} },
 
         %% sequence of shard numbers
         %% if you want to distribute the workload

--- a/corezoid/charts/worker/templates/worker-deployment.yaml
+++ b/corezoid/charts/worker/templates/worker-deployment.yaml
@@ -14,7 +14,6 @@ spec:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 0
-  replicas: {{ .Values.global.worker.minReplicas }}
   template:
     metadata:
       annotations:

--- a/corezoid/templates/postgres-cronjob.yaml
+++ b/corezoid/templates/postgres-cronjob.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       template:
         spec:
+          {{ if .Values.global.db.bouncer_affinity }}
+          affinity:
+            {{ .Values.global.db.bouncer_affinity | toYaml | nindent 12 | trim }}
+          {{- end}}
           containers:
             - image: postgres:13-alpine
               imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}

--- a/corezoid/templates/postgres-initdb-job.yaml
+++ b/corezoid/templates/postgres-initdb-job.yaml
@@ -15,6 +15,10 @@ spec:
         app: {{ .Values.global.product }}
         tier: postgres-job
     spec:
+      {{- if .Values.global.db.bouncer_affinity -}}
+      affinity:
+        {{ .Values.global.db.bouncer_affinity | toYaml | nindent 8 | trim }}
+      {{- end -}}
       restartPolicy: OnFailure
       containers:
         - image: "{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype}}/pg_schema:{{ .Values.global.db.postgres_schema.version }}"

--- a/corezoid/templates/postgres-post-install.yaml
+++ b/corezoid/templates/postgres-post-install.yaml
@@ -9,6 +9,10 @@ metadata:
   labels:
     tier: postgres
 spec:
+  {{ if .Values.global.db.bouncer_affinity }}
+  affinity:
+    {{ .Values.global.db.bouncer_affinity | toYaml | nindent 4 | trim }}
+  {{- end}}
   containers:
     - image: postgres:13-alpine
       imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -117,6 +117,28 @@ global:
       requests:
         cpu: "500m"
         memory: "500Mi"
+    bouncer_affinity: {}
+    #    # hard AZ-based affinity
+    #      podAntiAffinity:
+    #        requiredDuringSchedulingIgnoredDuringExecution:
+    #          - labelSelector:
+    #              matchExpressions:
+    #              - key: tier
+    #                operator: In
+    #                values:
+    #                  - pgbouncer
+    #            topologyKey: failure-domain.beta.kubernetes.io/zone
+    #    # soft AZ-based affinity
+    #      podAntiAffinity:
+    #        preferredDuringSchedulingIgnoredDuringExecution:
+    #          - labelSelector:
+    #              matchExpressions:
+    #                - key: tier
+    #                  operator: In
+    #                  values:
+    #                    - pgbouncer
+    #            topologyKey: failure-domain.beta.kubernetes.io/zone
+
     # Maximum number of client connections allowed.
     maxclientconn: "100000"
     # How many server connections to allow per user/database pair. Can be overridden in the per-database configuration.
@@ -358,6 +380,10 @@ global:
     ldap_bind_user_pass: ""
     ldap_user_nick_entry: "cn"
     ldap_tls: false
+    # max task size for process conv
+    max_task_size_for_process_conv: 264000
+    # max task size for state diagramm conv
+    max_task_size_for_st_diagramm_conv: 264000
     logic_settings:
       # max allowed threads for api logic
       api_max_thread: 50000
@@ -462,6 +488,8 @@ global:
         memory: 1000Mi
     # enigma private_key_id
     enigma_pk_id: ""
+    # max time for each execution of code, kill process after this time
+    max_exec_code_time: 1000
 
     affinity: {}
   #    # hard AZ-based affinity
@@ -533,6 +561,8 @@ global:
     ## true if pvc for mult should be created automaticaly
     ## false if you already have pvc
     persistantVolumeClaimCreate: true
+    # Support for explicit storage scheduler (eg: Stork)
+    schedulerName: ""
     # application resources limits and requests
     resources:
       limits:
@@ -649,6 +679,8 @@ global:
         # login/secret for corezoid-merchant communications
         merchant_login: apiLogin1
         merchant_secret: I9EmB170XUbe
+    minReplicas: 1
+    maxReplicas: 1
     # application resources limits and requests
     resources:
       limits:
@@ -710,6 +742,28 @@ global:
       requests:
         cpu: 1000m
         memory: 1000Mi
+    affinity: {}
+  #    # hard AZ-based affinity
+  #      podAntiAffinity:
+  #        requiredDuringSchedulingIgnoredDuringExecution:
+  #          - labelSelector:
+  #              matchExpressions:
+  #              - key: tier
+  #                operator: In
+  #                values:
+  #                  - conf-agent-server
+  #            topologyKey: failure-domain.beta.kubernetes.io/zone
+  #    # soft AZ-based affinity
+  #      podAntiAffinity:
+  #        preferredDuringSchedulingIgnoredDuringExecution:
+  #          - labelSelector:
+  #              matchExpressions:
+  #                - key: tier
+  #                  operator: In
+  #                  values:
+  #                    - conf-agent-server
+  #            topologyKey: failure-domain.beta.kubernetes.io/zone
+
 
   # web-superadm
   web_superadm:


### PR DESCRIPTION
Changelog:
- add pgbouncer affinity settings
- add conf-agent-server affinity settings
- add postgres jobs affinity settings
- add configurable value for capi, worker: max_task_size_for_process_conv, max_task_size_for_st_diagramm_conv
- add configurable value for capi: share_api_keys_in_company
- add configurable value for usercode: max_exec_code_time
- add configurable value for merchant: minReplicas, maxReplicas
- add mult optional value for configurable storage scheduler: schedulerName
- removed deployment replica definition for services that have HPA replica rules defined (capi, conf-agent-server, enigma, http-worker, merchant, mult, pgbouncer, syncapi, usercode, worker)