### PR TITLE
configuration change requests

### DIFF
--- a/corezoid/charts/capi/templates/capi-deployment.yaml
+++ b/corezoid/charts/capi/templates/capi-deployment.yaml
@@ -341,7 +341,7 @@ spec:
             name: {{ .Values.appName }}-config-vm
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if eq .Values.global.capi.auth_providers_enable true }}
         - name: {{ .Values.global.capi.capi_saml_secret_name | default "capi-saml-secret" }}
           secret:

--- a/corezoid/charts/capi/templates/capi-network-policy.yaml
+++ b/corezoid/charts/capi/templates/capi-network-policy.yaml
@@ -38,18 +38,6 @@ spec:
         - podSelector:
             matchLabels:
               tier: corezoid-web-adm
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.namespaceSelector | toYaml}}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.podSelector | toYaml }}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.namespaceSelector | toYaml }}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.podSelector | toYaml }}
-{{- end}}
+{{ .Values.global.networkPolicy.labelsSelector.ingress | toYaml | indent 4 }}
+{{ .Values.global.networkPolicy.labelsSelector.monitoring | toYaml | indent 4 }}
+{{- end }}

--- a/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
+++ b/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
@@ -172,7 +172,7 @@ spec:
             name: {{ .Values.appName }}-config
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.store_dumps.enabled }}
         - name: dumps-volume
           hostPath:

--- a/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
@@ -222,7 +222,7 @@ spec:
             name: {{ .Values.appName }}-config-vm
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.store_dumps.enabled }}
         - name: dumps-volume
           hostPath:

--- a/corezoid/charts/limits/templates/limits-deployment.yaml
+++ b/corezoid/charts/limits/templates/limits-deployment.yaml
@@ -192,7 +192,7 @@ spec:
             name: {{ .Values.appName }}-config
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.store_dumps.enabled }}
         - name: dumps-volume
           hostPath:

--- a/corezoid/charts/merchant/templates/merchant-deployment.yaml
+++ b/corezoid/charts/merchant/templates/merchant-deployment.yaml
@@ -15,9 +15,9 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/merchant-application-properties-configmap.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/merchant-callback-properties-configmap.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/merchant-datasource-configmap.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/merchant-log4j2-spring-configmap.yaml") . | sha256sum }}
+        # checksum/config: {{ include (print $.Template.BasePath "/merchant-callback-properties-configmap.yaml") . | sha256sum }}
+        # checksum/config: {{ include (print $.Template.BasePath "/merchant-datasource-configmap.yaml") . | sha256sum }}
+        # checksum/config: {{ include (print $.Template.BasePath "/merchant-log4j2-spring-configmap.yaml") . | sha256sum }}
         prometheus.io/path: /metrics
         prometheus.io/port: "9100"
         prometheus.io/scrape: "true"

--- a/corezoid/charts/mult/templates/mult-deployment.yaml
+++ b/corezoid/charts/mult/templates/mult-deployment.yaml
@@ -199,7 +199,7 @@ spec:
             name: {{ .Values.appName }}-config
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.mult.persistantVolumeClaimCreate }}
         - name: {{ .Values.appName }}-claim
           persistentVolumeClaim:

--- a/corezoid/charts/mult/templates/mult-network-policy.yaml
+++ b/corezoid/charts/mult/templates/mult-network-policy.yaml
@@ -22,18 +22,6 @@ spec:
         - podSelector:
             matchLabels:
               tier: mult
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.namespaceSelector | toYaml}}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.podSelector | toYaml }}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.namespaceSelector | toYaml }}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.podSelector | toYaml }}
-{{- end}}
+{{ .Values.global.networkPolicy.labelsSelector.ingress | toYaml | indent 4 }}
+{{ .Values.global.networkPolicy.labelsSelector.monitoring | toYaml | indent 4 }}
+{{- end }}

--- a/corezoid/charts/postgres/templates/postgres-deployment.yaml
+++ b/corezoid/charts/postgres/templates/postgres-deployment.yaml
@@ -34,10 +34,6 @@ spec:
             - name: {{ .Values.appName }}-claim
               mountPath: {{ .Values.postgresqlDataDir }}
               subPath: pgdata
-      volumes:
-        - name: {{ .Values.appName }}-claim
-          persistentVolumeClaim:
-            claimName: {{ .Values.appName }}-{{ .Values.global.storage}}-claim
       containers:
         - image: "postgres:13-alpine"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
@@ -100,6 +96,9 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.global.db.persistantVolumeClaimName }}
             readOnly: false
+        - name: {{ .Values.appName }}-claim
+          persistentVolumeClaim:
+            claimName: {{ .Values.appName }}-{{ .Values.global.storage}}-claim
       {{- if not  (eq .Values.global.repotype "public") }}
       imagePullSecrets:
         - name: corezoid-secret

--- a/corezoid/charts/syncapi/templates/syncapi-network-policy.yaml
+++ b/corezoid/charts/syncapi/templates/syncapi-network-policy.yaml
@@ -42,18 +42,6 @@ spec:
         - podSelector:
             matchLabels:
               tier: corezoid-web-adm
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.namespaceSelector | toYaml}}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.podSelector | toYaml }}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.namespaceSelector | toYaml }}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.podSelector | toYaml }}
-{{- end}}
+{{ .Values.global.networkPolicy.labelsSelector.ingress | toYaml | indent 4 }}
+{{ .Values.global.networkPolicy.labelsSelector.monitoring | toYaml | indent 4 }}
+{{- end }}

--- a/corezoid/charts/usercode/templates/usercode-deployment.yaml
+++ b/corezoid/charts/usercode/templates/usercode-deployment.yaml
@@ -212,7 +212,7 @@ spec:
             name: {{ .Values.appName }}-config
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.store_dumps.enabled }}
         - name: dumps-volume
           hostPath:

--- a/corezoid/charts/web/templates/web-network-policy.yaml
+++ b/corezoid/charts/web/templates/web-network-policy.yaml
@@ -14,18 +14,6 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.namespaceSelector | toYaml}}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.ingress.podSelector | toYaml }}
-    - from:
-        - namespaceSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.namespaceSelector | toYaml }}
-        - podSelector:
-            matchLabels:
-              {{ .Values.global.networkPolicy.labelsSelector.monitoring.podSelector | toYaml }}
-{{- end}}
+{{ .Values.global.networkPolicy.labelsSelector.ingress | toYaml | indent 4 }}
+{{ .Values.global.networkPolicy.labelsSelector.monitoring | toYaml | indent 4 }}
+{{- end }}

--- a/corezoid/charts/worker/templates/worker-deployment.yaml
+++ b/corezoid/charts/worker/templates/worker-deployment.yaml
@@ -253,7 +253,7 @@ spec:
             name: {{ .Values.appName }}-config-vm
         - name: corezoid-license
           secret:
-            secretName: license-share-new
+            secretName: {{ .Values.global.licenseSecretName | default "license-share-new" }}
         {{- if .Values.global.store_dumps.enabled }}
         - name: dumps-volume
           hostPath:

--- a/corezoid/templates/corezoid_license_secret.yaml
+++ b/corezoid/templates/corezoid_license_secret.yaml
@@ -1,11 +1,13 @@
+{{- if not .Values.global.existingLicenseSecret -}}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: license-share-new
+  name: {{ .Values.global.licenseSecretName | default "license-share-new" }}
 type: Opaque
 data:
   {{- $root := . -}}
   {{- range $path, $bytes := .Files.Glob "license/corezoid_license" }}
   corezoid_license: '{{ $root.Files.Get $path | b64enc }}'
   {{- end }}
+{{- end -}}

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -54,19 +54,25 @@ global:
     enabled: false
     labelsSelector:
       ingress:
-        namespaceSelector:
-          # Selector for ingress namespace
-          name: alb-ingress-nginx-internal
-        podSelector:
-          # Selector for ingress deploymnets
-          app.kubernetes.io/name: ingress-nginx
+        - from:
+          - namespaceSelector:
+              matchLabels:
+                # Selector for ingress namespace
+                name: alb-ingress-nginx-internal
+          - podSelector:
+              matchLabels:
+                # Selector for ingress deployments
+                app.kubernetes.io/name: ingress-nginx
       monitoring:
-        # Selector for prometheus namespace
-        namespaceSelector:
-          name: monitoring
-        # Selector for prometheus deploymnets
-        podSelector:
-          release: prometheus-stack
+        - from:
+            # Selector for prometheus namespace
+            - namespaceSelector:
+                matchLabels:
+                  name: monitoring
+            # Selector for prometheus deployments
+            - podSelector:
+                matchLabels:
+                  release: prometheus-stack
   ########  Settings for stateful services  ########
 
   #######  PostgreSQL  ########


### PR DESCRIPTION
**Case 1:** 
The labels in the values.yaml of the chart affect the rules that we want to create for our network policies. 
As the matchLabels is a map that accepts key value pairs, and when the other unique key added by the values.yaml from our parent chart(when the corezoid under the charts folder as a dependency) (for example, other than name or release keys defined in values.yaml), these labels comes from the chart too.

<img width="400" alt="image" src="https://user-images.githubusercontent.com/34839068/213588415-183a9572-d534-485b-a8be-1e7dcf5bf08d.png">

How to reproduce it:
- create a chart structure like here:
   ├── Chart.yaml
   ├── charts
    │   └── corezoid (corezoid chart need to be here as a dependency)
  └── values.yaml
- edit values.yaml like this 
  
<img width="200" alt="image" src="https://user-images.githubusercontent.com/34839068/213589735-0174538d-6672-41b4-a115-2da4c309d6ee.png">

- helm template -f values.yaml .

Error message:

  `Error: YAML parse error on mpo/charts/corezoid/charts/capi/templates/capi-network-policy.yaml: error converting YAML to JSON: yaml: line 44: mapping values are not allowed in this context`
  
**Case 2:** 
duplicate volume keyword on postgresql deployment
<img width="300" alt="image" src="https://user-images.githubusercontent.com/34839068/213657214-97639175-56f4-4033-b808-22faac191b93.png">


 **Case 3:** 
delete duplicate annotation with the same key on the merchant deployment


 **Case 4:** 
 adding option whether the chart should create the secret or not.
 secret's name and references in deployments can be edited from parent charts.
 
<img width="400" alt="image" src="https://user-images.githubusercontent.com/34839068/213667636-f213b94b-936c-4f49-b7fe-2bc5171f70ed.png">

 
It would be greatly appreciated if you could evaluate the work on changing network policy rules instead of changing selector.
