### PR TITLE
Optionally cover images with global registry name

### DIFF
--- a/corezoid/charts/capi/templates/capi-deployment.yaml
+++ b/corezoid/charts/capi/templates/capi-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 60
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until {{- if .Values.global.db.bouncer }} nc -zvw1 pgbouncer-service 5432 && {{- else }}  nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT} && {{- end }}  nc -zvw1  ${MQ_HOST} ${MQ_PORT}; do echo waiting for deps; sleep 2; done;"]
           env:
             - name: MQ_HOST
@@ -61,7 +61,7 @@ spec:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbport
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -84,7 +84,7 @@ spec:
                   name: {{ .Values.global.mq.secret.name }}
                   key: password
         - name: init-wait-elasticsearch
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -105,7 +105,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
         - name: init-wait-mult
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           imagePullPolicy: IfNotPresent
           command:
             - sh
@@ -118,7 +118,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          image: "{{ .Values.global.imageRegistry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.capi.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.capi.tag }}"
           env:
           - name: POD_NAME
             valueFrom:
@@ -328,10 +328,12 @@ spec:
             runAsUser: 1000
             capabilities:
               add: ["IPC_LOCK"]
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}config
           configMap:

--- a/corezoid/charts/capi/values.yaml
+++ b/corezoid/charts/capi/values.yaml
@@ -1,6 +1,10 @@
 appName: capi
 image:
   registry: docker-hub.middleware.biz
-  repository: /conveyor_api
+  repository: conveyor_api
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15
 containers:
   containerPort: 9080

--- a/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
+++ b/corezoid/charts/conf-agent-server/templates/conf-agent-server-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/postgresql-client:alpine3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.postgresqlClientImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.postgresqlClientImage.repository }}:{{ .Values.postgresqlClientImage.tag }}"
           command: ["sh", "-c", "until PGPASSWORD=${POSTGRES_DBPWD} psql -h ${POSTGRES_DBHOST} -U ${POSTGRES_DBUSER} -d settings -c \"select 1\" > /dev/null 2>&1 ; do echo Waiting while postgres created settings db ...; sleep 3; done"]
           env:
             - name: MQ_HOST
@@ -66,7 +66,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          image: "{{ .Values.global.imageRegistry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.conf_agent_server.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.conf_agent_server.tag }}"
           env:
             - name: POD_NAME
               valueFrom:
@@ -162,10 +162,12 @@ spec:
             {{- end }}
           resources:
             {{ .Values.global.conf_agent_server.resources | toYaml | indent 12 | trim }}
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}config
           configMap:

--- a/corezoid/charts/conf-agent-server/values.yaml
+++ b/corezoid/charts/conf-agent-server/values.yaml
@@ -1,7 +1,12 @@
 appName: conf-agent-server
 image:
   registry: docker-hub.middleware.biz
-  repository: /conf_agent_server
+  repository: conf_agent_server
+
+postgresqlClientImage:
+  registry: docker-hub.middleware.biz
+  repository: postgresql-client
+  tag: alpine3.15
 
 containers:
   containerPort: 8585

--- a/corezoid/charts/dumps/templates/dumps-deployments.yaml
+++ b/corezoid/charts/dumps/templates/dumps-deployments.yaml
@@ -119,10 +119,12 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}config
           configMap:

--- a/corezoid/charts/efs-provisioner/templates/deployment.yaml
+++ b/corezoid/charts/efs-provisioner/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
 {{- end }}
       containers:
       - name: {{ template "efs-provisioner.fullname" . }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: FILE_SYSTEM_ID
@@ -85,7 +85,7 @@ spec:
       {{- if ne .Values.efsProvisioner.path "/" }}
       initContainers:
       - name: "init-path"
-        image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
+        image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.busyboxImage.repository }}:{{ .Values.busyboxImage.tag }}"
         imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
         command: [ "sh", "-c", "mkdir -p /efs-vol-root/{{ (trimPrefix "/" .Values.efsProvisioner.path) }}" ]
         resources:

--- a/corezoid/charts/elasticsearch/templates/elasticsearch.yaml
+++ b/corezoid/charts/elasticsearch/templates/elasticsearch.yaml
@@ -21,19 +21,19 @@ spec:
     spec:
       initContainers:
         - name: increase-vm-max-map
-          image: docker-hub.middleware.biz/hub.docker.com/library/busybox
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.busyboxImage.registry }}/{{ .Values.busyboxImage.repository }}"
           command: ["sysctl", "-w", "vm.max_map_count=262144"]
           securityContext:
             privileged: true
         - name: increase-fd-ulimit
-          image: docker-hub.middleware.biz/hub.docker.com/library/busybox
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.busyboxImage.registry }}/{{ .Values.busyboxImage.repository }}"
           command: ["sh", "-c", "ulimit -n 65536"]
           securityContext:
             privileged: true
       containers:
         - name: {{ .Values.appName }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          image: "{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype | default "public" }}{{ .Values.image.repository }}:{{ .Values.global.elasticsearch.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ .Values.image.repository }}:{{ .Values.global.elasticsearch.tag }}"
           env:
             - name: discovery.type
               value: single-node
@@ -60,10 +60,12 @@ spec:
               path: /_cluster/health?local=true
               port: 9200
             initialDelaySeconds: 90
-       {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
-        {{- end }}
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+{{- end }}
 
 ---
 apiVersion: v1

--- a/corezoid/charts/elasticsearch/values.yaml
+++ b/corezoid/charts/elasticsearch/values.yaml
@@ -2,4 +2,8 @@ appName: elasticsearch
 
 image:
   registry: docker-hub.middleware.biz
-  repository: /elasticsearch
+  repository: elasticsearch
+
+busyboxImage:
+  registry: docker-hub.middleware.biz
+  repository: hub.docker.com/library/busybox

--- a/corezoid/charts/enigma-key-manager/templates/enigma-key-manager-deployment.yaml
+++ b/corezoid/charts/enigma-key-manager/templates/enigma-key-manager-deployment.yaml
@@ -29,7 +29,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until {{- if .Values.global.db.bouncer }} nc -zvw1 pgbouncer-service 5432 && {{- end }} nc -zvw1 postgresql 5432 {{- if not .Values.global.db.internal }} && nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT} {{- end }} ; do echo waiting for dependences; sleep 2; done;"]
           env:
             - name: POSTGRES_DBHOST
@@ -49,7 +49,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ .Values.global.repotype}}{{ .Values.image.repository }}:{{ .Values.global.enigma.key_manager.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.enigma.key_manager.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
           - name: POSTGRES_DBHOST
@@ -84,10 +84,12 @@ spec:
             - name: {{ .Values.appName }}-config
               mountPath: /ebsmnt/enigma-key-manager/config/production.json
               subPath: production.json
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}-config
           configMap:

--- a/corezoid/charts/enigma-key-manager/values.yaml
+++ b/corezoid/charts/enigma-key-manager/values.yaml
@@ -1,4 +1,9 @@
 appName: enigma-key-manager
 image:
   registry: docker-hub.middleware.biz
-  repository: /enigma-key-manager
+  repository: enigma-key-manager
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT} && {{- if .Values.global.mq.internal }} nc -zvw1 rabbit-service 5672 {{- else }} nc -zvw1  ${MQ_HOST} ${MQ_PORT} {{- end }}; do echo waiting for deps; sleep 2; done;"]
           env:
             - name: MQ_HOST
@@ -62,7 +62,7 @@ spec:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbport
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -87,7 +87,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName}}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.http.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.http.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: IPNODEDOMAIN
@@ -209,10 +209,12 @@ spec:
             {{- end }}
           resources:
             {{ .Values.global.http.resources | toYaml | indent 12 | trim }}
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName}}-config
           configMap:

--- a/corezoid/charts/http-worker/values.yaml
+++ b/corezoid/charts/http-worker/values.yaml
@@ -2,4 +2,9 @@ appName: http-worker
 
 image:
   registry: docker-hub.middleware.biz
-  repository: /http-worker
+  repository: http-worker
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/charts/limits/templates/limits-deployment.yaml
+++ b/corezoid/charts/limits/templates/limits-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "apk add postgresql-client; until PGPASSWORD=${POSTGRES_DBPWD} psql -h ${POSTGRES_DBHOST} -U ${POSTGRES_DBUSER} -d settings -c \"select 1\" > /dev/null 2>&1 ;  {{- if .Values.global.mq.internal }} nc -zvw1 rabbit-service 5672  {{- else }}  nc -zvw1  ${MQ_HOST} ${MQ_PORT}  {{- end }}; do echo waiting for dependences; sleep 3; done;"]
           env:
             - name: MQ_HOST
@@ -68,7 +68,7 @@ spec:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbpwd
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -94,7 +94,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.limits.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.limits.tag }}"
           env:
             {{- if .Values.global.store_dumps.enabled }}
             - name: ERL_CRASH_DUMP
@@ -182,10 +182,12 @@ spec:
             - name: dumps-volume
               mountPath: /var/dumps
             {{- end }}
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}config
           configMap:

--- a/corezoid/charts/limits/values.yaml
+++ b/corezoid/charts/limits/values.yaml
@@ -1,7 +1,12 @@
 appName: limits
 image:
   registry: docker-hub.middleware.biz
-  repository: /corezoid_limits
+  repository: corezoid_limits
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15
 
 containers:
   containerPort: 8585

--- a/corezoid/charts/merchant/templates/merchant-deployment.yaml
+++ b/corezoid/charts/merchant/templates/merchant-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/postgresql-client:alpine3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.postgresqlClientImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.postgresqlClientImage.repository }}:{{ .Values.postgresqlClientImage.tag }}"
           command: ["sh", "-c", "until PGPASSWORD=${POSTGRES_DBPWD} psql -h ${POSTGRES_DBHOST} -U ${POSTGRES_DBUSER} -d merchant -c \"select 1\" > /dev/null 2>&1 ; do echo Waiting while postgres created settings db ...; sleep 3; done"]
           env:
             - name: POSTGRES_DBHOST
@@ -62,7 +62,7 @@ spec:
       containers:
         - name: {{ .Values.appName }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-          image: "{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}{{ .Values.image.repository }}:{{ .Values.global.merchant.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.merchant.tag }}"
           env:
           - name: ES_JAVA_OPTS
             value: "-Dlog4j2.formatMsgNoLookups=true"
@@ -128,10 +128,12 @@ spec:
               subPath: log4j2-spring.xml
           resources:
             {{ .Values.global.merchant.resources | toYaml | indent 12 | trim }}
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}config
           configMap:

--- a/corezoid/charts/merchant/values.yaml
+++ b/corezoid/charts/merchant/values.yaml
@@ -1,7 +1,13 @@
 appName: merchant
 image:
   registry: docker-hub.middleware.biz
-  repository: /merchant
+  repository: merchant
+
+postgresqlClientImage:
+  registry: docker-hub.middleware.biz
+  repository: postgresql-client
+  tag: alpine3.15
+
 port:
 containers:
   containerPort: 8080

--- a/corezoid/charts/mult/templates/mult-deployment.yaml
+++ b/corezoid/charts/mult/templates/mult-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         fsGroup: 1000
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until  {{- if .Values.global.mq.internal }} nc -zvw1 rabbit-service 5672 {{- else }}  nc -zvw1  ${MQ_HOST} ${MQ_PORT} {{- end }}; do echo waiting for deps; sleep 2; done;"]
           env:
             - name: MQ_HOST
@@ -51,7 +51,7 @@ spec:
                   name: {{ .Values.global.mq.secret.name }}
                   key: port
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -76,7 +76,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.mult.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.mult.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: NODE_COOKIE
@@ -189,10 +189,12 @@ spec:
             runAsGroup: 1000
             capabilities:
               add: ["IPC_LOCK"]
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}-config
           configMap:

--- a/corezoid/charts/mult/values.yaml
+++ b/corezoid/charts/mult/values.yaml
@@ -1,4 +1,9 @@
 appName: mult
 image:
   registry: docker-hub.middleware.biz
-  repository: /conveyor_api_multipart
+  repository: conveyor_api_multipart
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/charts/nfs-provisioner/templates/statefulset.yaml
+++ b/corezoid/charts/nfs-provisioner/templates/statefulset.yaml
@@ -27,9 +27,15 @@ spec:
       # NOTE: This is 10 seconds longer than the default nfs-provisioner --grace-period value of 90sec
       terminationGracePeriodSeconds: 100
       serviceAccountName: {{ if .Values.rbac.create }}{{ template "nfs-provisioner.fullname" . }}{{ else }}{{ .Values.rbac.serviceAccountName | quote }}{{ end }}
+{{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+{{- end }}      
       containers:
-        - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        - name: {{ .Chart.Name }}         
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: nfs

--- a/corezoid/charts/pgbouncer/templates/pgbouncer-deployment.yaml
+++ b/corezoid/charts/pgbouncer/templates/pgbouncer-deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ .Values.global.repotype}}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: DB_USER
               valueFrom:
@@ -114,7 +114,7 @@ spec:
             successThreshold: 1
             failureThreshold: 3
         - name: pgbouncer-exporter
-          image: docker-hub.middleware.biz/public/prometheus-pgbouncer-exporter:2.1.1-python3.7.13-alpine3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.exporterImage.repository }}:{{ .Values.exporterImage.tag }}"
           env:
             - name: PGBOUNCER_EXPORTER_HOST
               value: 0.0.0.0
@@ -153,10 +153,12 @@ spec:
             requests:
               cpu: "50m"
               memory: "50Mi"
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       {{ if .Values.global.db.bouncer_affinity }}
       affinity:
         {{ .Values.global.db.bouncer_affinity | toYaml | nindent 8 | trim }}

--- a/corezoid/charts/pgbouncer/values.yaml
+++ b/corezoid/charts/pgbouncer/values.yaml
@@ -1,5 +1,10 @@
 appName: pgbouncer
 image:
   registry: docker-hub.middleware.biz
-  repository: /pgbouncer
+  repository: pgbouncer
   tag: 1.17.0-alpine3.16-2
+
+exporterImage:
+  registry: docker-hub.middleware.biz
+  repository: prometheus-pgbouncer-exporter
+  tag: 2.1.1-python3.7.13-alpine3.15

--- a/corezoid/charts/postgres/templates/postgres-deployment.yaml
+++ b/corezoid/charts/postgres/templates/postgres-deployment.yaml
@@ -21,7 +21,7 @@ spec:
       initContainers:
         #### https://github.com/docker-library/postgres/issues/563
         - name: pgsql-data-permission-fix
-          image: busybox
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.busyboxImage.repository }}:{{ .Values.busyboxImage.tag }}"
           command:
             - sh
             - -c
@@ -35,7 +35,7 @@ spec:
               mountPath: {{ .Values.postgresqlDataDir }}
               subPath: pgdata
       containers:
-        - image: "postgres:13-alpine"
+        - image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           name: {{ .Values.appName }}
           securityContext:
@@ -99,8 +99,10 @@ spec:
         - name: {{ .Values.appName }}-claim
           persistentVolumeClaim:
             claimName: {{ .Values.appName }}-{{ .Values.global.storage}}-claim
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/corezoid/charts/postgres/values.yaml
+++ b/corezoid/charts/postgres/values.yaml
@@ -1,4 +1,10 @@
 appName: postgresql
 postgresqlDataDir: /var/lib/pgsql/data
 image:
-  registry: docker-hub.middleware.biz
+  #registry: docker-hub.middleware.biz
+  repository: postgres
+  tag: 13-alpine
+
+busyboxImage:
+  repository: busybox
+  tag: latest

--- a/corezoid/charts/rabbitmq-ha/templates/statefulset.yaml
+++ b/corezoid/charts/rabbitmq-ha/templates/statefulset.yaml
@@ -42,19 +42,19 @@ spec:
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.image.pullSecrets }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-      {{- range .Values.image.pullSecrets }}
-        - name: {{ . }}
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
-      {{- end }}
+{{- end }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       securityContext:
 {{ toYaml .Values.securityContext | indent 10 }}
       serviceAccountName: {{ template "rabbitmq-ha.serviceAccountName" . }}
       initContainers:
         - name: bootstrap
-          image: {{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.busyboxImage.repository}}:{{ .Values.busyboxImage.tag}}"
           imagePullPolicy: {{ .Values.busyboxImage.pullPolicy }}
           command: ['sh']
           args:
@@ -95,7 +95,7 @@ spec:
 {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: epmd
@@ -203,7 +203,7 @@ spec:
             {{- end }}
         {{ if .Values.prometheus.exporter.enabled }}
         - name: {{ .Chart.Name }}-exporter
-          image: {{ .Values.prometheus.exporter.image.repository }}:{{ .Values.prometheus.exporter.image.tag }}
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.prometheus.exporter.image.repository }}:{{ .Values.prometheus.exporter.image.tag }}"
           imagePullPolicy: {{ .Values.prometheus.exporter.image.pullPolicy }}
           ports:
           - name: exporter

--- a/corezoid/charts/redis/templates/redis-deployment.yaml
+++ b/corezoid/charts/redis/templates/redis-deployment.yaml
@@ -41,7 +41,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: "{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         resources:
           limits:
             cpu: 300m
@@ -72,10 +72,12 @@ spec:
             mountPath: /usr/local/etc/redis
           - name: {{ .Values.appName }}-claim
             mountPath: /ebsmnt/data
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: redisconfig
           configMap:

--- a/corezoid/charts/redis/values.yaml
+++ b/corezoid/charts/redis/values.yaml
@@ -1,5 +1,5 @@
 appName: redis
 image:
   registry: docker-hub.middleware.biz
-  repository: /redis
+  repository: redis
   tag: 3.2.12

--- a/corezoid/charts/syncapi/templates/syncapi-deployment.yaml
+++ b/corezoid/charts/syncapi/templates/syncapi-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       initContainers:
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -58,7 +58,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.syncapi.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.syncapi.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: NODE_COOKIE
@@ -156,10 +156,12 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}-config
           configMap:

--- a/corezoid/charts/syncapi/values.yaml
+++ b/corezoid/charts/syncapi/values.yaml
@@ -1,4 +1,9 @@
 appName: syncapi
 image:
   registry: docker-hub.middleware.biz
-  repository: /corezoid_api_sync
+  repository: corezoid_api_sync
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/charts/usercode/templates/usercode-deployment.yaml
+++ b/corezoid/charts/usercode/templates/usercode-deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 40
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until {{- if .Values.global.db.bouncer }} nc -zvw1 pgbouncer-service 5432 && {{- else }}  nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT} && {{- end }} {{- if .Values.global.mq.internal }} nc -zvw1 rabbit-service 5672 {{- else }} nc -zvw1  ${MQ_HOST} ${MQ_PORT}{{- end }}; do echo waiting for dependences; sleep 2; done;"]
           env:
             - name: MQ_HOST
@@ -60,7 +60,7 @@ spec:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbport
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -85,7 +85,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.usercode.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.usercode.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: IPNODEDOMAIN
@@ -202,10 +202,12 @@ spec:
             timeoutSeconds: 5
             successThreshold: 1
             failureThreshold: 3
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: {{ .Values.appName }}-config
           configMap:

--- a/corezoid/charts/usercode/values.yaml
+++ b/corezoid/charts/usercode/values.yaml
@@ -1,4 +1,9 @@
 appName: usercode
 image:
   registry: docker-hub.middleware.biz
-  repository: /usercode
+  repository: usercode
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/charts/web-superadm/templates/web-superadm-deployment.yaml
+++ b/corezoid/charts/web-superadm/templates/web-superadm-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}{{ .Values.image.repository }}:{{ .Values.global.web_superadm.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.web_superadm.tag }}" 
           ports:
           - containerPort: 80
           volumeMounts:
@@ -64,10 +64,12 @@ spec:
             successThreshold: 1
             failureThreshold: 3
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: web-superadm-config-nginx
           configMap:

--- a/corezoid/charts/web-superadm/values.yaml
+++ b/corezoid/charts/web-superadm/values.yaml
@@ -1,4 +1,4 @@
 appName: corezoid-web-superadm
 image:
   registry: docker-hub.middleware.biz
-  repository: /conf_agent_admin
+  repository: conf_agent_admin

--- a/corezoid/charts/web/templates/web-deployment.yaml
+++ b/corezoid/charts/web/templates/web-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end}}
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ .Values.global.repotype | default "public" }}{{ .Values.image.repository }}:{{ .Values.global.webadm.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.webadm.tag }}"
           ports:
             - containerPort: 80
           lifecycle:
@@ -77,7 +77,7 @@ spec:
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
         - name: nginx-exporter
           # https://hub.docker.com/r/nginx/nginx-prometheus-exporter
-          image: nginx/nginx-prometheus-exporter
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.nginxExporter.registry }}/{{ .Values.nginxExporter.repository }}:{{ .Values.nginxExporter.tag }}"
           resources:
             requests:
               cpu: 10m
@@ -90,10 +90,12 @@ spec:
             - -nginx.scrape-uri=http://localhost/nginx_status
             #A number of retries the exporter will make on start to connect to the NGINX stub_status page
             - -nginx.retries=2
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: web-config-nginx
           configMap:

--- a/corezoid/charts/web/values.yaml
+++ b/corezoid/charts/web/values.yaml
@@ -1,4 +1,9 @@
 appName: corezoid-web-adm
 image:
   registry: docker-hub.middleware.biz
-  repository: /conveyor_adm_web
+  repository: conveyor_adm_web
+
+nginxExporter:
+  registry: nginx
+  repository: nginx-prometheus-exporter
+  tag: latest

--- a/corezoid/charts/worker/templates/worker-deployment.yaml
+++ b/corezoid/charts/worker/templates/worker-deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 600
       initContainers:
         - name: init-wait
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ["sh", "-c", "until nc -zvw1 ${POSTGRES_DBHOST} ${POSTGRES_DBPORT} &&  {{- if .Values.global.mq.internal }} nc -zvw1 rabbit-service 5672 {{- else }}  nc -zvw1  ${MQ_HOST} ${MQ_PORT} {{- end }} ; do echo waiting for dependences; sleep 2; done;"]
           env:
             - name: MQ_HOST
@@ -61,7 +61,7 @@ spec:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbport
         - name: init-wait-rmq
-          image: docker-hub.middleware.biz/public/alpine:3.15
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.alpineImage.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.alpineImage.repository }}:{{ .Values.alpineImage.tag }}"
           command: ['sh']
           args:
             - "-c"
@@ -86,7 +86,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: {{ .Values.appName }}
-          image: "{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}{{ else }}{{ .Values.global.repotype | default "public" }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.worker.tag }}"
+          image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.image.repository }}:{{ .Values.global.worker.tag }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           env:
             - name: NODE_COOKIE
@@ -240,10 +240,12 @@ spec:
             runAsUser: 1000
             capabilities:
               add: ["IPC_LOCK"]
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
       {{- end }}
+{{- end }}
       volumes:
         - name: workerconfig
           configMap:

--- a/corezoid/charts/worker/values.yaml
+++ b/corezoid/charts/worker/values.yaml
@@ -1,4 +1,9 @@
 appName: worker
 image:
   registry: docker-hub.middleware.biz
-  repository: /conveyor-worker
+  repository: conveyor-worker
+
+alpineImage:
+  registry: docker-hub.middleware.biz
+  repository: alpine
+  tag: 3.15

--- a/corezoid/templates/postgres-cronjob.yaml
+++ b/corezoid/templates/postgres-cronjob.yaml
@@ -25,7 +25,7 @@ spec:
             {{ .Values.global.db.bouncer_affinity | toYaml | nindent 12 | trim }}
           {{- end}}
           containers:
-            - image: postgres:13-alpine
+            - image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}postgres:13-alpine"
               imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
               name: postgres-taskarchive-cron
               command:

--- a/corezoid/templates/postgres-initdb-job.yaml
+++ b/corezoid/templates/postgres-initdb-job.yaml
@@ -21,7 +21,7 @@ spec:
       {{- end }}
       restartPolicy: OnFailure
       containers:
-        - image: "{{ .Values.global.imageRegistry }}/{{ .Values.global.repotype}}/pg_schema:{{ .Values.global.db.postgres_schema.version }}"
+        - image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.global.db.postgres_schema.image.registry }}/{{ if .Values.global.useCentos8 }}{{ .Values.global.centos8Repo }}/{{ else }}{{- if not (eq .Values.global.repotype "") }}{{ .Values.global.repotype }}/{{- end }}{{ end }}{{ .Values.global.db.postgres_schema.image.repository }}:{{ .Values.global.db.postgres_schema.version }}"
           imagePullPolicy: {{ .Values.global.imagePullPolicy | default "IfNotPresent" }}
           name: postgres-initdb
           args:
@@ -75,8 +75,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.db.secret.name }}
                   key: dbpwd_fdw
-      {{- if not  (eq .Values.global.repotype "public") }}
+{{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
-        - name: corezoid-secret
-  {{- end }}
+      {{- range $pullSecret := .Values.global.imagePullSecrets }}
+        - name: {{ $pullSecret }}
+      {{- end }}
+{{- end }}
 

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -8,6 +8,10 @@ global:
   imageRegistry: "docker-hub.middleware.biz"
   #IfNotPresent | Always | Never
   imagePullPolicy: "IfNotPresent"
+  # If specified, use these secrets to access the images, this can be used on mCloud.
+  # imagePullSecrets:
+  #   - ecr-registry
+  #   - gitlab-registry
   repotype: "public"
   product: "corezoid"
   centos8Repo: public-corezoid-centos8
@@ -170,6 +174,9 @@ global:
 
     # Postgres corezoid schema version
     postgres_schema:
+      image:
+        registry: docker-hub.middleware.biz
+        repository: pg_schema
       version: "5.10.0.4"
       db_schema_rds: true  # if RDS base then set to true, if standard PostgreSQL then false
 


### PR DESCRIPTION
**optionally covering the container image names with the other private registry**

tests after this changes:
1-)
when the imageRegistry: "docker-hub.middleware.biz" and repotype: "corezoid",
images are the same as before, see for test-1.txt
[test-1.txt](https://github.com/corezoid/helm/files/10793575/test-1.txt)
2-)
when the imageRegistry: "docker-hub.middleware.biz" and repotype: "" (empty),
image name changes regarding to repotype option, see for test-2.txt
[test-2.txt](https://github.com/corezoid/helm/files/10793576/test-2.txt)
3-)
when the imageRegistry: "another-registry-name.com" and repotype: "" (empty),
images names are having prefix of value of the imageRegistry, for test-3.txt
[test-3.txt](https://github.com/corezoid/helm/files/10793577/test-3.txt)


**imagePullSecret logic change, not relying on the repotype variable.
if it mentioned globally, it will be added to everywhere. if not, it wont be added.**

tests after this change:

1-) 
When the value exist in values.yaml

  imagePullSecrets:
    - ecr-registry
    - gitlab-registry
  
 This imagePullSecrets added to manifest 

2-) 
When the value does not exist or was commented

This imagePullSecrets didn't added to manifest 