### PR TITLE
feat(MAM-1155): switch to using the .spec.ingressClassName

### DIFF
--- a/corezoid/charts/ingress/templates/cz-eks-ingress-api-2.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-api-2.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress-api.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-api.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress-auth.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-auth.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress-root.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-root.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress-system.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-system.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/charts/ingress/templates/cz-eks-ingress-user_download.yaml
+++ b/corezoid/charts/ingress/templates/cz-eks-ingress-user_download.yaml
@@ -9,6 +9,7 @@ metadata:
     app: {{ .Values.global.product }}
     tier: {{ .Values.appName }}
 spec:
+  {{- include "ingress.className" . | nindent 2 }}
   rules:
     - host: {{ .Values.global.subdomain}}.{{ .Values.global.domain }}
       http:

--- a/corezoid/templates/_helpers.tpl
+++ b/corezoid/templates/_helpers.tpl
@@ -1,7 +1,10 @@
+{{- define "ingress.className" -}}
+{{- if .Values.global.ingress.className -}}
+ingressClassName: {{ .Values.global.ingress.className }}
+{{- end -}}
+{{- end -}}
+
 {{- define "corezoid-auth.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
       more_set_headers "Cache-Control: no-cache";
@@ -10,13 +13,10 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
       add_header X-Frame-Options "SAMEORIGIN";
       add_header X-Content-Type-Options "nosniff";
       add_header Content-Security-Policy "default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self'";
-  {{- end }}
+{{- end -}}
 
 
 {{- define "corezoid-root.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers X-Content-Type-Options "nosniff" always;
@@ -27,13 +27,10 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
   add_header X-Content-Type-Options nosniff;
   add_header Permissions-Policy "geolocation=(), camera=()";
   add_header 'Referrer-Policy' 'no-referrer-when-downgrade';
-  {{- end }}
+{{- end -}}
 
 
 {{- define "corezoid-api.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers X-Content-Type-Options "nosniff" always;
@@ -41,41 +38,32 @@ nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
   add_header X-Frame-Options "SAMEORIGIN";
   add_header Content-Security-Policy "default-src 'self' https://*.gravatar.com https://upload.wikimedia.org https://*.gstatic.com https://www.google.com https://www.google-analytics.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} wss://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}/* wss://{{ .Values.global.subdomain}}.{{ .Values.global.domain }}/* 'unsafe-inline'; frame-src 'self' https://*.gravatar.com https://*.google.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}; script-src 'self' https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://*.gravatar.com https://*.gstatic.com https://www.google.com https://www.googletagmanager.com https://ajax.googleapis.com https://www.google-analytics.com 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net wss://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}; img-src 'self' data: https://*.gravatar.com https://upload.wikimedia.org https://www.google.com https://www.google.com.ua https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://www.google-analytics.com  https://*.gstatic.com data:; object-src 'self'; font-src 'self' https://*.gravatar.com https://*.gstatic.com https://www.google.com https://fonts.gstatic.com https://fonts.googleapis.com data:; style-src * blob: 'self' https://*.gravatar.com https://*.gstatic.com https://www.google.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://fonts.gstatic.com https://fonts.googleapis.com 'unsafe-inline';";
-{{- end }}
+{{- end -}}
 
 
 {{- define "corezoid-api-2.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers X-Content-Type-Options "nosniff" always;
   more_set_headers "Strict-Transport-Security: max-age=31536000; includeSubDomains";
   add_header Content-Security-Policy "default-src 'self' https://*.gravatar.com https://upload.wikimedia.org https://*.gstatic.com https://www.google.com https://www.google-analytics.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} wss://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}/* wss://{{ .Values.global.subdomain}}.{{ .Values.global.domain }}/* 'unsafe-inline'; frame-src 'self' https://*.gravatar.com https://*.google.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}; script-src 'self' https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://*.gravatar.com https://*.gstatic.com https://www.google.com https://www.googletagmanager.com https://ajax.googleapis.com https://www.google-analytics.com 'unsafe-inline' 'unsafe-eval'; connect-src 'self' https://www.google-analytics.com https://stats.g.doubleclick.net wss://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }}; img-src 'self' data: https://*.gravatar.com https://upload.wikimedia.org https://www.google.com https://www.google.com.ua https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://www.google-analytics.com  https://*.gstatic.com data:; object-src 'self'; font-src 'self' https://*.gravatar.com https://*.gstatic.com https://www.google.com https://fonts.gstatic.com https://fonts.googleapis.com data:; style-src * blob: 'self' https://*.gravatar.com https://*.gstatic.com https://www.google.com https://*.{{ .Values.global.subdomain}}.{{ .Values.global.domain }} https://fonts.gstatic.com https://fonts.googleapis.com 'unsafe-inline';";
-{{- end }}
+{{- end -}}
 
 
 {{- define "corezoid-system.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers X-Content-Type-Options "nosniff" always;
   add_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
   add_header X-Content-Type-Options "nosniff";
-{{- end }}
+{{- end -}}
 
 
 {{- define "corezoid-user-download.ingressAnnotations" -}}
-  {{- if .Values.global.ingress.className }}
-kubernetes.io/ingress.class: {{ .Values.global.ingress.className }}
-  {{- end }}
 nginx.ingress.kubernetes.io/ssl-redirect: "true"
 nginx.ingress.kubernetes.io/configuration-snippet: |
   more_set_headers X-Content-Type-Options "nosniff" always;
-{{- end }}
+{{- end -}}
 
 
 


### PR DESCRIPTION
- This chart is currently using the deprecated [kubernetes.io/ingress.class](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-ingress-class-deprecated) annotation, this PR aims to switch to using the .spec.ingressClassName. 
- Remove additional new lines output for ingressAnnotations.