### PR TITLE
Update capi-saml-secret.yaml

### DIFF
--- a/corezoid/templates/capi-saml-secret.yaml
+++ b/corezoid/templates/capi-saml-secret.yaml
@@ -1,19 +1,4 @@
-{{- if .Values.global.capi.auth_providers_enable  }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.global.capi.capi_saml_secret_name | default "capi-saml-secret" }}
-  labels:
-    app: {{ .Values.global.product }}
-    tier: "capi"
-type: Opaque
-data:
-{{- range $k, $v := $.Values.global.capi.saml_idp }}
-  {{ $k }}_metadata.xml:
-{{ toYaml $v.auth_metadata_content | b64enc | indent 4 }}
-{{- end }}
-{{- end }}
-{{- if .Values.global.capi.auth_providers_saml_enable  }}
+{{- if or .Values.global.capi.auth_providers_enable .Values.global.capi.auth_providers_saml_enable }}
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
remove duplicated properties when both` .Values.global.capi.auth_providers_enable` and `.Values.global.capi.auth_providers_saml_enable ` are set to `true`