### PR TITLE
adding nginx.scrape-uri param back

### DIFF
--- a/corezoid/charts/web/templates/web-deployment.yaml
+++ b/corezoid/charts/web/templates/web-deployment.yaml
@@ -95,6 +95,9 @@ spec:
         - name: nginx-exporter
           # https://hub.docker.com/r/nginx/nginx-prometheus-exporter
           image: "{{- if and (ne .Values.global.imageRegistry "") (ne .Values.global.imageRegistry "docker-hub.middleware.biz") }}{{ .Values.global.imageRegistry }}/{{- end}}{{ .Values.nginxExporter.registry }}/{{ .Values.nginxExporter.repository }}:{{ .Values.nginxExporter.tag }}"
+          args:
+            #A URI or unix domain socket path for scraping NGINX
+            - -nginx.scrape-uri=http://localhost:{{ .Values.global.webadm.service_port | default 8080 }}/nginx_status          
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
Adding back` nginx.scrape-uri ` param to `nginx-exporter `container to fix the following scrape error
`caller=nginx.go:58 level=error msg="Error getting stats" error="expected 200 response, got 404"`

It was removed here https://github.com/corezoid/helm/compare/0.23.0...0.23.1#diff-05dc9c49a8c971907318a0ce18d636525682e34fb496bc7942d316c886984d55L107