### PR TITLE
chore: make webadm preStop sleep configurable

### DIFF
--- a/corezoid/charts/web/templates/web-deployment.yaml
+++ b/corezoid/charts/web/templates/web-deployment.yaml
@@ -55,7 +55,7 @@ spec:
             preStop:
               exec:
                 #waiting for the pod to be removed from the service
-                command: ["/bin/sleep","3"]
+                command: ["/bin/sleep","{{ .Values.global.webadm.preStopSleepSeconds | default 3 }}"]
           volumeMounts:
             - name: web-config-nginx
               mountPath: /etc/nginx/nginx.conf


### PR DESCRIPTION
While testing the availability of WebADM, we noticed that the WebADM pods were being terminated too quickly in Kubernetes environment. 
With this change, we aim to make the preStop sleep configurable, and we're planning to change it more than initialDelaySeconds.