### PR TITLE
Configmap fix redis

### DIFF
--- a/corezoid/CHANGELOG.md
+++ b/corezoid/CHANGELOG.md
@@ -1,6 +1,30 @@
 ## Changelog
 https://doc.corezoid.com/docs/release-notes
 
+### Chart 0.24.9 [ Corezoid 6.11.0 ]
+
+#### Applications versions:
+- capi - 8.8.1.1
+- mult - 3.7.0.1
+- web - 6.11.1
+- http-worker - 4.5.1.2
+- usercode - 9.2.2
+- worker - 5.6.0.1
+- syncapi - 3.8.1
+- web_superadm - 2.6.2
+- conf_agent_server - 2.10.1
+- conf_agent_admin - 2.6.2
+- limits - 2.5.1
+
+#### Configmap fix
+- Added ability to configure a second Redis cache instance in `redis2` block for **worker**, **capi**, and **http-worker** configmaps
+  - Configuration is centralized in `global.redis.secret.data` (`host_cache_second`, `port_cache_second`, `password_cache_second`)
+  - Set once — applies to all three services automatically
+  - Second instance block is only added when `host_cache_second` is defined
+- Added ability to configure a second Redis timers instance in `redis_timers` block for **worker** configmap only
+  - Configuration in `global.redis.secret.data` (`host_timers_second`, `port_timers_second`, `password_timers_second`)
+  - Second instance block is only added when `host_timers_second` is defined
+
 ### Chart 0.24.8 [ Corezoid 6.11.0 ]
 
 #### Applications versions:

--- a/corezoid/Chart.yaml
+++ b/corezoid/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: corezoid
-version: "0.24.8"
+version: "0.24.9"
 appVersion: "6.11.0"
 description: Chart for Corezoid.
 home: https://corezoid.com/

--- a/corezoid/charts/capi/templates/capi-configmap.yaml
+++ b/corezoid/charts/capi/templates/capi-configmap.yaml
@@ -968,6 +968,19 @@ data:
                     {min_size, 10},
                     {max_size, 50}
                 ]
+    {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+                ,
+                [
+                    {host, "${REDIS_HOST_CACHE_SECOND}"},
+                    {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
+                    {port, ${REDIS_PORT_CACHE_SECOND}},
+                    {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+                    {database, {{ .Values.global.capi.redis2_second_database | default 3 }}},
+                    {start_size, {{ .Values.global.capi.redis2_second_start_size | default 10 }}},
+                    {min_size, {{ .Values.global.capi.redis2_second_min_size | default 10 }}},
+                    {max_size, {{ .Values.global.capi.redis2_second_max_size | default 50 }}}
+                ]
+    {{- end }}
             ]},
 
             %% redis pool for api_sum logic

--- a/corezoid/charts/capi/templates/capi-deployment.yaml
+++ b/corezoid/charts/capi/templates/capi-deployment.yaml
@@ -262,6 +262,23 @@ spec:
               secretKeyRef:
                 name: {{ .Values.global.redis.secret.name }}
                 key: password_cache
+          {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+          - name: REDIS_HOST_CACHE_SECOND
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.global.redis.secret.name }}
+                key: host_cache_second
+          - name: REDIS_PORT_CACHE_SECOND
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.global.redis.secret.name }}
+                key: port_cache_second
+          - name: REDIS_PASSWORD_CACHE_SECOND
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.global.redis.secret.name }}
+                key: password_cache_second
+          {{- end }}
           - name: MQ_HOST
             valueFrom:
               secretKeyRef:

--- a/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
@@ -341,6 +341,19 @@ data:
             {min_size, 20},
             {max_size, 100}
           ]
+    {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+          ,
+          [
+            {host, "${REDIS_HOST_CACHE_SECOND}"},
+            {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
+            {port, ${REDIS_PORT_CACHE_SECOND}},
+            {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+            {database, {{ .Values.global.http.redis_second_database | default 3 }}},
+            {start_size, {{ .Values.global.http.redis_second_start_size | default 20 }}},
+            {min_size, {{ .Values.global.http.redis_second_min_size | default 20 }}},
+            {max_size, {{ .Values.global.http.redis_second_max_size | default 100 }}}
+          ]
+    {{- end }}
         ]},
 
         % http answer

--- a/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-deployment.yaml
@@ -233,7 +233,23 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.redis.secret.name }}
                   key: password_cache
-
+            {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+            - name: REDIS_HOST_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: host_cache_second
+            - name: REDIS_PORT_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: port_cache_second
+            - name: REDIS_PASSWORD_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: password_cache_second
+            {{- end }}
             - name: MQ_HOST
               valueFrom:
                 secretKeyRef:

--- a/corezoid/charts/worker/templates/worker-configmap.yaml
+++ b/corezoid/charts/worker/templates/worker-configmap.yaml
@@ -750,6 +750,19 @@ data:
             {min_size, {{ .Values.global.worker.redis2_min_size | default 5 }}},
             {max_size, {{ .Values.global.worker.redis2_max_size | default 100 }}}
           ]
+    {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+          ,
+          [
+            {host, "${REDIS_HOST_CACHE_SECOND}"},
+            {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
+            {port, ${REDIS_PORT_CACHE_SECOND}},
+            {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+            {database, {{ .Values.global.worker.redis2_second_database | default 3 }}},
+            {start_size, {{ .Values.global.worker.redis2_second_start_size | default 5 }}},
+            {min_size, {{ .Values.global.worker.redis2_second_min_size | default 5 }}},
+            {max_size, {{ .Values.global.worker.redis2_second_max_size | default 100 }}}
+          ]
+    {{- end }}
         ]},
 
         %% memory redis for timer calls
@@ -786,6 +799,19 @@ data:
             {min_size, {{ .Values.global.worker.redis_timers_min_size | default 5 }}},
             {max_size, {{ .Values.global.worker.redis_timers_max_size | default 50 }}}
           ]
+    {{- if and (hasKey .Values.global.redis.secret.data "host_timers_second") .Values.global.redis.secret.data.host_timers_second }}
+          ,
+          [
+            {host, "${REDIS_HOST_TIMERS_SECOND}"},
+            {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
+            {port, ${REDIS_PORT_TIMERS_SECOND}},
+            {password,"${REDIS_PASSWORD_TIMERS_SECOND}"},
+            {database, {{ .Values.global.worker.redis_timers_second_database | default 4 }}},
+            {start_size, {{ .Values.global.worker.redis_timers_second_start_size | default 5 }}},
+            {min_size, {{ .Values.global.worker.redis_timers_second_min_size | default 5 }}},
+            {max_size, {{ .Values.global.worker.redis_timers_second_max_size | default 50 }}}
+          ]
+    {{- end }}
         ]},
 
         %% cache size in redis2

--- a/corezoid/charts/worker/templates/worker-deployment.yaml
+++ b/corezoid/charts/worker/templates/worker-deployment.yaml
@@ -247,6 +247,40 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.redis.secret.name }}
                   key: password_timers
+            {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
+            - name: REDIS_HOST_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: host_cache_second
+            - name: REDIS_PORT_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: port_cache_second
+            - name: REDIS_PASSWORD_CACHE_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: password_cache_second
+            {{- end }}
+            {{- if and (hasKey .Values.global.redis.secret.data "host_timers_second") .Values.global.redis.secret.data.host_timers_second }}
+            - name: REDIS_HOST_TIMERS_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: host_timers_second
+            - name: REDIS_PORT_TIMERS_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: port_timers_second
+            - name: REDIS_PASSWORD_TIMERS_SECOND
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.redis.secret.name }}
+                  key: password_timers_second
+            {{- end }}
             - name: MQ_HOST
               valueFrom:
                 secretKeyRef:

--- a/corezoid/templates/_helpers.tpl
+++ b/corezoid/templates/_helpers.tpl
@@ -51,6 +51,32 @@ app: {{ .Values.global.product | quote }}
 {{- .Values.global.redis.secret.data.password_timers | default .Values.global.redis.secret.data.password -}}
 {{- end -}}
 
+## cache second instance
+{{- define "redis.host_cache_second" -}}
+{{- .Values.global.redis.secret.data.host_cache_second | default "" -}}
+{{- end -}}
+
+{{- define "redis.port_cache_second" -}}
+{{- .Values.global.redis.secret.data.port_cache_second | default "" -}}
+{{- end -}}
+
+{{- define "redis.password_cache_second" -}}
+{{- .Values.global.redis.secret.data.password_cache_second | default "" -}}
+{{- end -}}
+
+## timers second instance
+{{- define "redis.host_timers_second" -}}
+{{- .Values.global.redis.secret.data.host_timers_second | default "" -}}
+{{- end -}}
+
+{{- define "redis.port_timers_second" -}}
+{{- .Values.global.redis.secret.data.port_timers_second | default "" -}}
+{{- end -}}
+
+{{- define "redis.password_timers_second" -}}
+{{- .Values.global.redis.secret.data.password_timers_second | default "" -}}
+{{- end -}}
+
 {{- define "common.imagePullSecrets" -}}
 {{- if not (eq .Values.global.repotype "public") }}
 imagePullSecrets:

--- a/corezoid/templates/redis-secret.yaml
+++ b/corezoid/templates/redis-secret.yaml
@@ -10,7 +10,7 @@ metadata:
 type: Opaque
 data:
   {{- range $key, $value := .Values.global.redis.secret.data }}
-  {{- if or (hasSuffix "_cache" $key) (hasSuffix "_timers" $key) }}
+  {{- if or (hasSuffix "_cache" $key) (hasSuffix "_timers" $key) (hasSuffix "_cache_second" $key) (hasSuffix "_timers_second" $key) }}
   {{- $overrideKey := printf "%s.%s" "redis" $key }}
   {{ $key }}: {{ (include $overrideKey $) | b64enc | quote }}
   {{- else }}

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -271,6 +271,14 @@ global:
         host_timers: ""
         port_timers: ""
         password_timers: ""
+        # Second redis for cache - set host to enable second instance in redis2 block (capi, http-worker, worker)
+        # host_cache_second: "REDIS_CACHE_SECOND_HOST"
+        # port_cache_second: "6382"
+        # password_cache_second: ""
+        # Second redis for timers - set host to enable second instance in redis_timers block (worker only)
+        # host_timers_second: "REDIS_TIMERS_SECOND_HOST"
+        # port_timers_second: "6383"
+        # password_timers_second: ""
 #     redistype: elasticache  # only to AWS elasticache redis
     affinity: {}
 #     affinity:


### PR DESCRIPTION
#### Configmap fix

* Added ability to configure a second Redis cache instance in `redis2` block for **worker**, **capi**, and **http-worker** configmaps
  * Configuration is centralized in `global.redis.secret.data` (`host_cache_second`, `port_cache_second`, `password_cache_second`)
  * Set once — applies to all three services automatically
  * Second instance block is only added when `host_cache_second` is defined
* Added ability to configure a second Redis timers instance in `redis_timers` block for **worker** configmap only
  * Configuration in `global.redis.secret.data` (`host_timers_second`, `port_timers_second`, `password_timers_second`)
  * Second instance block is only added when `host_timers_second` is defined