### PR TITLE
Release Chart 0.25.0 [Corezoid 6.12.0]

### DIFF
--- a/corezoid/CHANGELOG.md
+++ b/corezoid/CHANGELOG.md
@@ -1,6 +1,33 @@
 ## Changelog
 https://doc.corezoid.com/docs/release-notes
 
+### Chart 0.25.0 [ Corezoid 6.12.0 ]
+
+#### Applications versions:
+- capi - 8.9.0.4
+- mult - 3.9.0.6
+- web - 6.12.0
+- http-worker - 4.5.1.3
+- usercode - 9.2.2
+- worker - 5.6.0.3
+- syncapi - 3.8.1
+- web_superadm - 2.6.3
+- conf_agent_server - 2.11.2
+- conf_agent_admin - 2.6.3
+- limits - 2.5.1
+
+#### Updated applications
+- capi - 8.9.0.4
+- mult (conveyor_api_multipart) - 3.9.0.6
+- web (webadm) - 6.12.0
+- http-worker - 4.5.1.3
+- worker - 5.6.0.3
+- web_superadm (conf_agent_admin) - 2.6.3
+- conf_agent_server - 2.11.2
+
+#### Bug Fixes
+- Fixed Erlang config parse error on pod startup when `global.redis.secret.data.host_cache_second` (or `host_timers_second`) is set: configmaps for `capi`, `worker`, `http-worker` now use direct Helm template values instead of env-var placeholders for the second Redis instance — affects only deployments that enable the second Redis cache/timers instance (AE-14124).
+
 ### Chart 0.24.9 [ Corezoid 6.11.0 ]
 
 #### Applications versions:

--- a/corezoid/Chart.yaml
+++ b/corezoid/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: corezoid
-version: "0.24.9"
-appVersion: "6.11.0"
+version: "0.25.0"
+appVersion: "6.12.0"
 description: Chart for Corezoid.
 home: https://corezoid.com/
 maintainers:

--- a/corezoid/charts/capi/Chart.yaml
+++ b/corezoid/charts/capi/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "8.8.1.1"
+appVersion: "8.9.0.4"
 description: A Helm chart for Kubernetes
 name: capi
-version: 1.1.4
+version: 1.1.5

--- a/corezoid/charts/capi/templates/capi-configmap.yaml
+++ b/corezoid/charts/capi/templates/capi-configmap.yaml
@@ -460,7 +460,7 @@ data:
         ]},
 
         {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },
@@ -971,10 +971,10 @@ data:
     {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
                 ,
                 [
-                    {host, "${REDIS_HOST_CACHE_SECOND}"},
+                    {host, "{{ .Values.global.redis.secret.data.host_cache_second }}"},
                     {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
-                    {port, ${REDIS_PORT_CACHE_SECOND}},
-                    {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+                    {port, {{ .Values.global.redis.secret.data.port_cache_second }}},
+                    {password,"{{ .Values.global.redis.secret.data.password_cache_second }}"},
                     {database, {{ .Values.global.capi.redis2_second_database | default 3 }}},
                     {start_size, {{ .Values.global.capi.redis2_second_start_size | default 10 }}},
                     {min_size, {{ .Values.global.capi.redis2_second_min_size | default 10 }}},

--- a/corezoid/charts/conf-agent-server/Chart.yaml
+++ b/corezoid/charts/conf-agent-server/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.10.1"
+appVersion: "2.11.2"
 description: A Helm chart for Kubernetes
 name: conf-agent-server
-version: 1.0.3
+version: 1.0.4

--- a/corezoid/charts/conf-agent-server/templates/conf-agent-server-configmap.yaml
+++ b/corezoid/charts/conf-agent-server/templates/conf-agent-server-configmap.yaml
@@ -44,7 +44,7 @@ data:
       ]},
 
       {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },

--- a/corezoid/charts/http-worker/Chart.yaml
+++ b/corezoid/charts/http-worker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "4.5.1.2"
+appVersion: "4.5.1.3"
 description: A Helm chart for Kubernetes
 name: http-worker
-version: 1.0.3
+version: 1.0.4

--- a/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
@@ -215,7 +215,7 @@ data:
            ]},
 
         {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },
@@ -344,10 +344,10 @@ data:
     {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
           ,
           [
-            {host, "${REDIS_HOST_CACHE_SECOND}"},
+            {host, "{{ .Values.global.redis.secret.data.host_cache_second }}"},
             {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
-            {port, ${REDIS_PORT_CACHE_SECOND}},
-            {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+            {port, {{ .Values.global.redis.secret.data.port_cache_second }}},
+            {password,"{{ .Values.global.redis.secret.data.password_cache_second }}"},
             {database, {{ .Values.global.http.redis_second_database | default 3 }}},
             {start_size, {{ .Values.global.http.redis_second_start_size | default 20 }}},
             {min_size, {{ .Values.global.http.redis_second_min_size | default 20 }}},

--- a/corezoid/charts/limits/templates/limits-configmap.yaml
+++ b/corezoid/charts/limits/templates/limits-configmap.yaml
@@ -78,7 +78,7 @@ data:
         ]},
 
       {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },

--- a/corezoid/charts/mult/Chart.yaml
+++ b/corezoid/charts/mult/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "3.7.0.1"
+appVersion: "3.9.0.6"
 description: A Helm chart for Kubernetes
 name: mult
-version: 1.0.3
+version: 1.0.4

--- a/corezoid/charts/mult/templates/mult-configmap.yaml
+++ b/corezoid/charts/mult/templates/mult-configmap.yaml
@@ -220,7 +220,7 @@ data:
       ]},
 
         {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },

--- a/corezoid/charts/postgres_schema/Chart.yaml
+++ b/corezoid/charts/postgres_schema/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6.11.0"
+appVersion: "6.12.0"
 description: A Helm chart for Postgres Schema
 name: postgres_schema
 version: 1.1.2

--- a/corezoid/charts/syncapi/templates/syncapi-configmap.yaml
+++ b/corezoid/charts/syncapi/templates/syncapi-configmap.yaml
@@ -85,7 +85,7 @@ data:
       ]},
 
       {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },

--- a/corezoid/charts/usercode/templates/usercode-configmap.yaml
+++ b/corezoid/charts/usercode/templates/usercode-configmap.yaml
@@ -134,7 +134,7 @@ data:
         ]},
 
         {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },

--- a/corezoid/charts/web-superadm/Chart.yaml
+++ b/corezoid/charts/web-superadm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "2.6.2"
+appVersion: "2.6.3"
 description: A Helm chart for Kubernetes
 name: web-superadm
-version: 1.0.1
+version: 1.0.2

--- a/corezoid/charts/web/Chart.yaml
+++ b/corezoid/charts/web/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "6.11.1"
+appVersion: "6.12.0"
 description: A Helm chart for Kubernetes
 name: web
-version: 1.1.4
+version: 1.1.5

--- a/corezoid/charts/worker/Chart.yaml
+++ b/corezoid/charts/worker/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "5.6.0.1"
+appVersion: "5.6.0.3"
 description: A Helm chart for Kubernetes
 name: worker
-version: 1.1.3
+version: 1.1.4

--- a/corezoid/charts/worker/templates/worker-configmap.yaml
+++ b/corezoid/charts/worker/templates/worker-configmap.yaml
@@ -428,7 +428,7 @@ data:
         ]},
 
         {corezoid_queues_gc, [
-          {enabled, true},
+          {disabled, false},
           {{- if hasKey .Values.global "mq_http" }}
           {host, "${MQ_HTTP_HOST}"},
           {port, 15672 },
@@ -753,10 +753,10 @@ data:
     {{- if and (hasKey .Values.global.redis.secret.data "host_cache_second") .Values.global.redis.secret.data.host_cache_second }}
           ,
           [
-            {host, "${REDIS_HOST_CACHE_SECOND}"},
+            {host, "{{ .Values.global.redis.secret.data.host_cache_second }}"},
             {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
-            {port, ${REDIS_PORT_CACHE_SECOND}},
-            {password,"${REDIS_PASSWORD_CACHE_SECOND}"},
+            {port, {{ .Values.global.redis.secret.data.port_cache_second }}},
+            {password,"{{ .Values.global.redis.secret.data.password_cache_second }}"},
             {database, {{ .Values.global.worker.redis2_second_database | default 3 }}},
             {start_size, {{ .Values.global.worker.redis2_second_start_size | default 5 }}},
             {min_size, {{ .Values.global.worker.redis2_second_min_size | default 5 }}},
@@ -802,10 +802,10 @@ data:
     {{- if and (hasKey .Values.global.redis.secret.data "host_timers_second") .Values.global.redis.secret.data.host_timers_second }}
           ,
           [
-            {host, "${REDIS_HOST_TIMERS_SECOND}"},
+            {host, "{{ .Values.global.redis.secret.data.host_timers_second }}"},
             {instance_type, {{ .Values.global.redis.redistype | default "redis" }}},
-            {port, ${REDIS_PORT_TIMERS_SECOND}},
-            {password,"${REDIS_PASSWORD_TIMERS_SECOND}"},
+            {port, {{ .Values.global.redis.secret.data.port_timers_second }}},
+            {password,"{{ .Values.global.redis.secret.data.password_timers_second }}"},
             {database, {{ .Values.global.worker.redis_timers_second_database | default 4 }}},
             {start_size, {{ .Values.global.worker.redis_timers_second_start_size | default 5 }}},
             {min_size, {{ .Values.global.worker.redis_timers_second_min_size | default 5 }}},


### PR DESCRIPTION
Synced from internal git.corezoid.com:kubernetes/helm/corezoid-k8s-developers @main (tag 0.25.0). Includes:

- Application bumps: capi 8.9.0.4, mult 3.9.0.6, web 6.12.0, http-worker 4.5.1.3, worker 5.6.0.3, web_superadm/conf_agent_admin 2.6.3, conf_agent_server 2.11.2
- AE-14124 fix: redis2 second-instance configmap uses direct Helm template values instead of env-var placeholders (capi/worker/http-worker)
- Cumulative corezoid_queues_gc configmap fixes (disabled: false) across capi/conf-agent-server/http-worker/limits/mult/syncapi/usercode/worker
- postgres_schema appVersion bumped to 6.12.0