### PR TITLE
Release Chart 0.25.1 [Corezoid 6.12.0]

### DIFF
--- a/corezoid/CHANGELOG.md
+++ b/corezoid/CHANGELOG.md
@@ -1,6 +1,27 @@
 ## Changelog
 https://doc.corezoid.com/docs/release-notes
 
+### Chart 0.25.1 [ Corezoid 6.12.0 ]
+
+#### Applications versions:
+- capi - 8.9.0.4
+- mult - 3.9.0.6
+- web - 6.12.0
+- http-worker - 4.5.1.3
+- usercode - 9.2.2
+- worker - 5.6.0.3
+- syncapi - 3.8.1
+- web_superadm - 2.6.3
+- conf_agent_server - 2.11.2
+- conf_agent_admin - 2.6.3
+- limits - 2.5.1
+
+#### Updated applications
+- (no application version changes)
+
+#### Bug Fixes
+- Added `global.http.dns_rebinding_protection` toggle for http-worker (default `false`): renders `{dns_rebinding_protection, true|false}` into the http_worker config to enable DNS rebinding / SSRF protection. Active only together with a non-empty `global.http.blocked_domains`. Available since http-worker 4.5.1.1 (current chart ships 4.5.1.3) (MAM-1269).
+
 ### Chart 0.25.0 [ Corezoid 6.12.0 ]
 
 #### Applications versions:

--- a/corezoid/Chart.yaml
+++ b/corezoid/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: corezoid
-version: "0.25.0"
+version: "0.25.1"
 appVersion: "6.12.0"
 description: Chart for Corezoid.
 home: https://corezoid.com/

--- a/corezoid/charts/http-worker/Chart.yaml
+++ b/corezoid/charts/http-worker/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.5.1.3"
 description: A Helm chart for Kubernetes
 name: http-worker
-version: 1.0.4
+version: 1.0.5

--- a/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
+++ b/corezoid/charts/http-worker/templates/http-worker-configmap.yaml
@@ -260,6 +260,9 @@ data:
         {{- end }}
 
         {max_keep_alive_connections_len, {{ .Values.global.http.max_keep_alive_connections_len | default "0" }} }, %% use for poolling keep-alive connections. If zerro it'll open new connection each query
+        %% DNS rebinding protection (SSRF). Resolves host to IP once and pins it.
+        %% Active only when enabled AND blocked_domains is non-empty.
+        {dns_rebinding_protection, {{ .Values.global.http.dns_rebinding_protection | default false }} },
         {blocked_domains, [
         {{- range .Values.global.http.blocked_domains  }}
         {{ . | quote }},{{- end }}

--- a/corezoid/values.yaml
+++ b/corezoid/values.yaml
@@ -567,6 +567,8 @@ global:
         memory: 500Mi
     max_keep_alive_connections_len: "0"
     max_http_resp_size: "5242880"
+    # DNS rebinding (SSRF) protection. Requires a non-empty blocked_domains to be active.
+    dns_rebinding_protection: false
     blocked_domains:
       - "169.254.169.254"
       - "mail.ru"


### PR DESCRIPTION
Add global.http.dns_rebinding_protection toggle for http-worker (default false), rendered as {dns_rebinding_protection, true|false} in the http_worker config. Enables DNS rebinding / SSRF protection already present in the http-worker image (since 4.5.1.1; chart ships 4.5.1.3). Active only together with a non-empty global.http.blocked_domains.

No application version changes. Chart 0.25.0 -> 0.25.1, http-worker subchart 1.0.4 -> 1.0.5. Verified with helm template.

Ref: MAM-1269